### PR TITLE
fix: Replace resource location parameter with hardcoded 'australiaeas…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -85,8 +85,8 @@
 /avm/res/desktop-virtualization/host-pool/ @Azure/avm-res-desktopvirtualization-hostpool-module-owners-bicep @Azure/avm-module-reviewers-bicep
 /avm/res/desktop-virtualization/scaling-plan/ @Azure/avm-res-desktopvirtualization-scalingplan-module-owners-bicep @Azure/avm-module-reviewers-bicep
 /avm/res/desktop-virtualization/workspace/ @Azure/avm-res-desktopvirtualization-workspace-module-owners-bicep @Azure/avm-module-reviewers-bicep
-/avm/res/dev-ops-infrastructure/pool/ @Azure/avm-res-devopsinfrastructure-pool-module-owners-bicep @Azure/avm-module-reviewers-bicep
 /avm/res/dev-center/network-connection @Azure/avm-res-devcenter-networkconnection-module-owners-bicep @Azure/avm-module-reviewers-bicep
+/avm/res/dev-ops-infrastructure/pool/ @Azure/avm-res-devopsinfrastructure-pool-module-owners-bicep @Azure/avm-module-reviewers-bicep
 /avm/res/dev-test-lab/lab/ @Azure/avm-res-devtestlab-lab-module-owners-bicep @Azure/avm-module-reviewers-bicep
 /avm/res/digital-twins/digital-twins-instance/ @Azure/avm-res-digitaltwins-digitaltwinsinstance-module-owners-bicep @Azure/avm-module-reviewers-bicep
 /avm/res/document-db/database-account/ @Azure/avm-res-documentdb-databaseaccount-module-owners-bicep @Azure/avm-module-reviewers-bicep

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -85,7 +85,7 @@
 /avm/res/desktop-virtualization/host-pool/ @Azure/avm-res-desktopvirtualization-hostpool-module-owners-bicep @Azure/avm-module-reviewers-bicep
 /avm/res/desktop-virtualization/scaling-plan/ @Azure/avm-res-desktopvirtualization-scalingplan-module-owners-bicep @Azure/avm-module-reviewers-bicep
 /avm/res/desktop-virtualization/workspace/ @Azure/avm-res-desktopvirtualization-workspace-module-owners-bicep @Azure/avm-module-reviewers-bicep
-/avm/res/dev-center/network-connection @Azure/avm-res-devcenter-networkconnection-module-owners-bicep @Azure/avm-module-reviewers-bicep
+/avm/res/dev-center/network-connection/ @Azure/avm-res-devcenter-networkconnection-module-owners-bicep @Azure/avm-module-reviewers-bicep
 /avm/res/dev-ops-infrastructure/pool/ @Azure/avm-res-devopsinfrastructure-pool-module-owners-bicep @Azure/avm-module-reviewers-bicep
 /avm/res/dev-test-lab/lab/ @Azure/avm-res-devtestlab-lab-module-owners-bicep @Azure/avm-module-reviewers-bicep
 /avm/res/digital-twins/digital-twins-instance/ @Azure/avm-res-digitaltwins-digitaltwinsinstance-module-owners-bicep @Azure/avm-module-reviewers-bicep

--- a/.github/ISSUE_TEMPLATE/avm_module_issue.yml
+++ b/.github/ISSUE_TEMPLATE/avm_module_issue.yml
@@ -120,6 +120,7 @@ body:
         - "avm/res/desktop-virtualization/host-pool"
         - "avm/res/desktop-virtualization/scaling-plan"
         - "avm/res/desktop-virtualization/workspace"
+        - "avm/res/dev-center/network-connection"
         - "avm/res/dev-ops-infrastructure/pool"
         - "avm/res/dev-test-lab/lab"
         - "avm/res/digital-twins/digital-twins-instance"

--- a/avm/res/dev-center/network-connection/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/dev-center/network-connection/tests/e2e/defaults/main.test.bicep
@@ -17,9 +17,9 @@ param serviceShort string = 'dcncmin'
 @description('Optional. A token to inject into the name of each resource. This value can be automatically injected by the CI.')
 param namePrefix string = '#_namePrefix_#'
 
-// Hardcoded to 'australiaeast' because service not available in all regions
+// Hardcoded because service not available in all regions
 #disable-next-line no-hardcoded-location
-var enforcedLocation = 'australiaeast'
+var enforcedLocation = 'uksouth'
 
 // ============ //
 // Dependencies //

--- a/avm/res/dev-center/network-connection/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/dev-center/network-connection/tests/e2e/defaults/main.test.bicep
@@ -11,14 +11,15 @@ metadata description = 'This instance deploys the module with the minimum set of
 @maxLength(90)
 param resourceGroupName string = 'dep-${namePrefix}-devcenter.networkconnection-${serviceShort}-rg'
 
-@description('Optional. The location to deploy resources to.')
-param resourceLocation string = deployment().location
-
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 param serviceShort string = 'dcncmin'
 
 @description('Optional. A token to inject into the name of each resource. This value can be automatically injected by the CI.')
 param namePrefix string = '#_namePrefix_#'
+
+// Hardcoded to 'australiaeast' because service not available in all regions
+#disable-next-line no-hardcoded-location
+var enforcedLocation = 'australiaeast'
 
 // ============ //
 // Dependencies //
@@ -28,15 +29,15 @@ param namePrefix string = '#_namePrefix_#'
 // =================
 resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: resourceGroupName
-  location: resourceLocation
+  location: enforcedLocation
 }
 
 module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
-  name: '${uniqueString(deployment().name, resourceLocation)}-nestedDependencies'
+  name: '${uniqueString(deployment().name, enforcedLocation)}-nestedDependencies'
   params: {
     virtualNetworkName: 'dep-${namePrefix}-vnet-${serviceShort}'
-    location: resourceLocation
+    location: enforcedLocation
   }
 }
 
@@ -48,10 +49,10 @@ module nestedDependencies 'dependencies.bicep' = {
 module testDeployment '../../../main.bicep' = [
   for iteration in ['init', 'idem']: {
     scope: resourceGroup
-    name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
+    name: '${uniqueString(deployment().name, enforcedLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: resourceLocation
+      location: enforcedLocation
       subnetResourceId: nestedDependencies.outputs.subnetResourceId
     }
   }

--- a/avm/res/dev-center/network-connection/tests/e2e/max/main.test.bicep
+++ b/avm/res/dev-center/network-connection/tests/e2e/max/main.test.bicep
@@ -11,9 +11,6 @@ metadata description = 'This instance deploys the module with most of its featur
 @maxLength(90)
 param resourceGroupName string = 'dep-${namePrefix}-devcenter-networkconnection-${serviceShort}-rg'
 
-@description('Optional. The location to deploy resources to.')
-param resourceLocation string = deployment().location
-
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 param serviceShort string = 'dcncmax'
 
@@ -24,6 +21,10 @@ param namePrefix string = '#_namePrefix_#'
 @secure()
 param password string = newGuid()
 
+// Hardcoded to 'australiaeast' because service not available in all regions
+#disable-next-line no-hardcoded-location
+var enforcedLocation = 'australiaeast'
+
 // ============ //
 // Dependencies //
 // ============ //
@@ -33,16 +34,16 @@ param password string = newGuid()
 
 resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: resourceGroupName
-  location: resourceLocation
+  location: enforcedLocation
 }
 
 module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
-  name: '${uniqueString(deployment().name, resourceLocation)}-nestedDependencies'
+  name: '${uniqueString(deployment().name, enforcedLocation)}-nestedDependencies'
   params: {
     virtualNetworkName: 'dep-${namePrefix}-vnet-${serviceShort}'
     managedIdentityName: 'dep-${namePrefix}-mi-${serviceShort}'
-    location: resourceLocation
+    location: enforcedLocation
   }
 }
 
@@ -54,10 +55,10 @@ module nestedDependencies 'dependencies.bicep' = {
 module testDeployment '../../../main.bicep' = [
   for iteration in ['init', 'idem']: {
     scope: resourceGroup
-    name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
+    name: '${uniqueString(deployment().name, enforcedLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: resourceLocation
+      location: enforcedLocation
       lock: {
         kind: 'CanNotDelete'
         name: 'myCustomLockName'

--- a/avm/res/dev-center/network-connection/tests/e2e/max/main.test.bicep
+++ b/avm/res/dev-center/network-connection/tests/e2e/max/main.test.bicep
@@ -21,7 +21,7 @@ param namePrefix string = '#_namePrefix_#'
 @secure()
 param password string = newGuid()
 
-// Hardcoded to 'australiaeast' because service not available in all regions
+// Hardcoded because service not available in all regions
 #disable-next-line no-hardcoded-location
 var enforcedLocation = 'australiaeast'
 

--- a/avm/res/dev-center/network-connection/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/dev-center/network-connection/tests/e2e/waf-aligned/main.test.bicep
@@ -17,7 +17,7 @@ param serviceShort string = 'dcncwaf'
 @description('Optional. A token to inject into the name of each resource. This value can be automatically injected by the CI.')
 param namePrefix string = '#_namePrefix_#'
 
-// Hardcoded to 'australiaeast' because service not available in all regions
+// Hardcoded because service not available in all regions
 #disable-next-line no-hardcoded-location
 var enforcedLocation = 'australiaeast'
 

--- a/avm/res/dev-center/network-connection/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/dev-center/network-connection/tests/e2e/waf-aligned/main.test.bicep
@@ -11,14 +11,15 @@ metadata description = 'This instance deploys the module in alignment with the b
 @maxLength(90)
 param resourceGroupName string = 'dep-${namePrefix}-devcenter.networkconnection-${serviceShort}-rg'
 
-@description('Optional. The location to deploy resources to.')
-param resourceLocation string = deployment().location
-
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 param serviceShort string = 'dcncwaf'
 
 @description('Optional. A token to inject into the name of each resource. This value can be automatically injected by the CI.')
 param namePrefix string = '#_namePrefix_#'
+
+// Hardcoded to 'australiaeast' because service not available in all regions
+#disable-next-line no-hardcoded-location
+var enforcedLocation = 'australiaeast'
 
 // ============ //
 // Dependencies //
@@ -28,15 +29,15 @@ param namePrefix string = '#_namePrefix_#'
 // =================
 resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: resourceGroupName
-  location: resourceLocation
+  location: enforcedLocation
 }
 
 module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
-  name: '${uniqueString(deployment().name, resourceLocation)}-nestedDependencies'
+  name: '${uniqueString(deployment().name, enforcedLocation)}-nestedDependencies'
   params: {
     virtualNetworkName: 'dep-${namePrefix}-vnet-${serviceShort}'
-    location: resourceLocation
+    location: enforcedLocation
   }
 }
 
@@ -48,10 +49,10 @@ module nestedDependencies 'dependencies.bicep' = {
 module testDeployment '../../../main.bicep' = [
   for iteration in ['init', 'idem']: {
     scope: resourceGroup
-    name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
+    name: '${uniqueString(deployment().name, enforcedLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: resourceLocation
+      location: enforcedLocation
       subnetResourceId: nestedDependencies.outputs.subnetResourceId
       domainJoinType: 'AzureADJoin'
       networkingResourceGroupName: 'rg-${namePrefix}${serviceShort}-networking'

--- a/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/scripts/provision-ad.ps1
+++ b/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/scripts/provision-ad.ps1
@@ -24,8 +24,6 @@ param(
 
 $script:ErrorActionPreference = 'Stop'
 
-Start-Sleep -Seconds 180 # sleep for 3 minutes
-
 try {
     $username = "$($DomainFQDN.Split('.')[0])\$AdministratorAccount"
     $securePassword = ConvertTo-SecureString $AdministratorPassword -AsPlainText -Force

--- a/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/scripts/provision-arc.ps1
+++ b/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/scripts/provision-arc.ps1
@@ -94,7 +94,7 @@ try {
         Write-Output 'Waiting for Edge device resource to be ready'
         Start-Sleep -Seconds 600
         $waitInterval = 60
-        $maxWaitCount = 30
+        $maxWaitCount = 10
         $ready = $false
         for ($waitCount = 0; $job.JobState -ne 'Transferred' -and $waitCount -lt $maxWaitCount; $waitCount++) {
             Connect-AzAccount -ServicePrincipal -Credential $credential -Subscription $Using:SubscriptionId -Tenant $Using:TenantId | Out-Null


### PR DESCRIPTION
…t' in test files for consistency

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|          |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
